### PR TITLE
[VA] #20: Implementar código fonte do va-link (Link Shortener)

### DIFF
--- a/crates/va-link-server/Cargo.toml
+++ b/crates/va-link-server/Cargo.toml
@@ -7,9 +7,25 @@ edition = "2024"
 axum.workspace = true
 tokio.workspace = true
 serde.workspace = true
-serde_json.workspace = true
+serde_json = "1.0.115"
 anyhow.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-sqlx.workspace = true
+
+sqlx = { version = "0.7.4", features = ["runtime-tokio-rustls", "postgres", "macros", "uuid", "chrono"] }
+uuid = { version = "1.8.0", features = ["serde", "v4"] }
+chrono = { version = "0.4.37", features = ["serde"] }
+rand = "0.8.5"
+url = "2.5.0"
+validator = { version = "0.18.1", features = ["derive"] }
+dotenvy = "0.15.7"
+
+# For middleware
+tower-http = { version = "0.5.2", features = ["trace", "cors"] }
+
+[dev-dependencies]
+http-body-util = "0.1.1"
+hyper = { version = "1.2.0", features = ["full"] }
+hyper-util = { version = "0.1.3", features = ["full"] }
+tokio-test = "0.4.4"

--- a/crates/va-link-server/migrations/20260305000000_init.sql
+++ b/crates/va-link-server/migrations/20260305000000_init.sql
@@ -1,0 +1,24 @@
+-- Add migration script here
+CREATE TABLE IF NOT EXISTS short_links (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    original_url TEXT NOT NULL,
+    short_code VARCHAR(20) NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ,
+    user_id UUID, -- Optional: Link to a user if authentication is implemented
+    clicks BIGINT NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_short_code ON short_links (short_code);
+CREATE INDEX IF NOT EXISTS idx_original_url ON short_links (original_url);
+
+CREATE TABLE IF NOT EXISTS clicks (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    short_link_id UUID NOT NULL,
+    clicked_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ip_address VARCHAR(45), -- IPv4 or IPv6
+    user_agent TEXT,
+    FOREIGN KEY (short_link_id) REFERENCES short_links(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_clicks_short_link_id ON clicks (short_link_id);

--- a/crates/va-link-server/src/config.rs
+++ b/crates/va-link-server/src/config.rs
@@ -1,0 +1,35 @@
+use anyhow::Result;
+use dotenvy::dotenv;
+use serde::{Deserialize, Serialize};
+use std::env;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppConfig {
+    pub database_url: String,
+    pub server_address: String,
+    pub short_code_length: usize,
+    pub base_url: String,
+}
+
+impl AppConfig {
+    pub fn load() -> Result<Self> {
+        dotenv().ok(); // Load .env file if it exists
+
+        let database_url = env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://postgres:password@localhost:5432/va_link".to_string());
+        let server_address =
+            env::var("SERVER_ADDRESS").unwrap_or_else(|_| "0.0.0.0:8080".to_string());
+        let short_code_length = env::var("SHORT_CODE_LENGTH")
+            .unwrap_or_else(|_| "7".to_string())
+            .parse::<usize>()
+            .expect("SHORT_CODE_LENGTH must be a valid integer");
+        let base_url = env::var("BASE_URL").unwrap_or_else(|_| "http://localhost:8080".to_string());
+
+        Ok(AppConfig {
+            database_url,
+            server_address,
+            short_code_length,
+            base_url,
+        })
+    }
+}

--- a/crates/va-link-server/src/db.rs
+++ b/crates/va-link-server/src/db.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+use sqlx::{
+    PgPool,
+    migrate::Migrator,
+    postgres::{PgPoolOptions, PgRow},
+};
+
+pub type DbPool = PgPool;
+
+pub async fn init_db_pool(database_url: &str) -> Result<DbPool> {
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(database_url)
+        .await?;
+
+    Ok(pool)
+}
+
+pub async fn run_migrations(pool: &DbPool) -> Result<()> {
+    // This path is relative to the Cargo.toml of the crate
+    let migrator = Migrator::new(std::path::Path::new("./migrations")).await?;
+    migrator.run(pool).await?;
+    tracing::info!("Database migrations applied successfully.");
+    Ok(())
+}
+
+// Re-export PgRow for convenience in models/handlers if needed
+pub use PgRow;

--- a/crates/va-link-server/src/error.rs
+++ b/crates/va-link-server/src/error.rs
@@ -1,0 +1,69 @@
+use axum::{
+    Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde_json::json;
+use thiserror::Error;
+use tracing::error;
+use validator::ValidationErrors;
+
+#[derive(Debug, Error)]
+pub enum AppError {
+    #[error("Database error: {0}")]
+    Sqlx(#[from] sqlx::Error),
+
+    #[error("Validation error: {0}")]
+    Validation(#[from] ValidationErrors),
+
+    #[error("URL parsing error: {0}")]
+    UrlParse(#[from] url::ParseError),
+
+    #[error("Link not found")]
+    NotFound,
+
+    #[error("Short code already exists")]
+    Conflict,
+
+    #[error("Internal server error: {0}")]
+    Anyhow(#[from] anyhow::Error),
+
+    #[error("Bad request: {0}")]
+    BadRequest(String),
+
+    #[error("Axum internal error: {0}")]
+    Axum(#[from] axum::Error),
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let (status, error_message) = match &self {
+            AppError::Sqlx(e) => {
+                error!("SQLX Error: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Database error".to_string(),
+                )
+            }
+            AppError::Validation(e) => (StatusCode::BAD_REQUEST, e.to_string()),
+            AppError::UrlParse(e) => (StatusCode::BAD_REQUEST, e.to_string()),
+            AppError::NotFound => (StatusCode::NOT_FOUND, "Resource not found".to_string()),
+            AppError::Conflict => (
+                StatusCode::CONFLICT,
+                "Short code already exists".to_string(),
+            ),
+            AppError::Anyhow(e) => {
+                error!("Anyhow Error: {:?}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal server error".to_string(),
+                )
+            }
+            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            AppError::Axum(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+        };
+
+        let body = Json(json!({ "error": error_message }));
+        (status, body).into_response()
+    }
+}

--- a/crates/va-link-server/src/handlers.rs
+++ b/crates/va-link-server/src/handlers.rs
@@ -1,0 +1,204 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Redirect},
+};
+use chrono::{Duration, Utc};
+use rand::{Rng, distributions::Alphanumeric};
+use sqlx::{PgPool, query, query_as};
+use url::Url;
+use validator::Validate;
+
+use crate::{
+    config::AppConfig,
+    error::AppError,
+    models::{Click, CreateLinkRequest, LinkStats, ShortLink, ShortLinkResponse},
+};
+
+pub type AppState = State<AppStateData>;
+
+#[derive(Clone)]
+pub struct AppStateData {
+    pub pool: PgPool,
+    pub config: AppConfig,
+}
+
+pub async fn health_check() -> impl IntoResponse {
+    StatusCode::OK
+}
+
+pub async fn create_short_link(
+    State(state): AppState,
+    Json(mut req): Json<CreateLinkRequest>,
+) -> Result<Json<ShortLinkResponse>, AppError> {
+    req.validate()?;
+
+    // Validate original_url is a valid URL
+    Url::parse(&req.original_url)?;
+
+    let short_code = if let Some(custom_code) = req.custom_short_code {
+        // Check if custom code already exists
+        let existing_link = query_as!(
+            ShortLink,
+            "SELECT * FROM short_links WHERE short_code = $1",
+            custom_code
+        )
+        .fetch_optional(&state.pool)
+        .await?;
+
+        if existing_link.is_some() {
+            return Err(AppError::Conflict);
+        }
+        custom_code
+    } else {
+        // Generate a random short code
+        generate_unique_short_code(&state.pool, state.config.short_code_length).await?
+    };
+
+    let created_at = Utc::now();
+    let expires_at = req.expires_at; // Can be None
+
+    let new_link = query_as!(
+        ShortLink,
+        "INSERT INTO short_links (id, original_url, short_code, created_at, expires_at, clicks)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         RETURNING id, original_url, short_code, created_at, expires_at, user_id, clicks",
+        Uuid::new_v4(),
+        req.original_url,
+        short_code,
+        created_at,
+        expires_at,
+        0i64
+    )
+    .fetch_one(&state.pool)
+    .await?;
+
+    let full_short_url = format!("{}/{}", state.config.base_url, new_link.short_code);
+
+    Ok(Json(ShortLinkResponse {
+        id: new_link.id,
+        original_url: new_link.original_url,
+        short_code: new_link.short_code,
+        full_short_url,
+        created_at: new_link.created_at,
+        expires_at: new_link.expires_at,
+        clicks: new_link.clicks,
+    }))
+}
+
+pub async fn redirect_short_link(
+    State(state): AppState,
+    Path(short_code): Path<String>,
+    headers: axum::http::HeaderMap,
+) -> Result<Redirect, AppError> {
+    let link = query_as!(
+        ShortLink,
+        "SELECT * FROM short_links WHERE short_code = $1",
+        short_code
+    )
+    .fetch_optional(&state.pool)
+    .await?;
+
+    let link = match link {
+        Some(l) => l,
+        None => return Err(AppError::NotFound),
+    };
+
+    // Check if link has expired
+    if let Some(expires_at) = link.expires_at {
+        if Utc::now() > expires_at {
+            return Err(AppError::NotFound); // Or a specific "Expired" error
+        }
+    }
+
+    // Record click
+    let ip_address = headers
+        .get("X-Forwarded-For")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let user_agent = headers
+        .get("User-Agent")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    query!(
+        "INSERT INTO clicks (id, short_link_id, clicked_at, ip_address, user_agent)
+         VALUES ($1, $2, $3, $4, $5)",
+        Uuid::new_v4(),
+        link.id,
+        Utc::now(),
+        ip_address,
+        user_agent
+    )
+    .execute(&state.pool)
+    .await?;
+
+    // Increment click count on short_links table
+    query!(
+        "UPDATE short_links SET clicks = clicks + 1 WHERE id = $1",
+        link.id
+    )
+    .execute(&state.pool)
+    .await?;
+
+    Ok(Redirect::to(&link.original_url))
+}
+
+pub async fn get_link_stats(
+    State(state): AppState,
+    Path(short_code): Path<String>,
+) -> Result<Json<LinkStats>, AppError> {
+    let short_link = query_as!(
+        ShortLink,
+        "SELECT * FROM short_links WHERE short_code = $1",
+        short_code
+    )
+    .fetch_optional(&state.pool)
+    .await?
+    .ok_or(AppError::NotFound)?;
+
+    let total_clicks = query!(
+        "SELECT COUNT(*) as count FROM clicks WHERE short_link_id = $1",
+        short_link.id
+    )
+    .fetch_one(&state.pool)
+    .await?
+    .count
+    .unwrap_or(0); // COUNT(*) returns BIGINT, so it's i64
+
+    let last_click_at = query!(
+        "SELECT MAX(clicked_at) as last_click FROM clicks WHERE short_link_id = $1",
+        short_link.id
+    )
+    .fetch_one(&state.pool)
+    .await?
+    .last_click;
+
+    Ok(Json(LinkStats {
+        short_link,
+        total_clicks,
+        last_click_at,
+    }))
+}
+
+async fn generate_unique_short_code(pool: &PgPool, length: usize) -> Result<String, AppError> {
+    loop {
+        let code: String = rand::thread_rng()
+            .sample_iter(&Alphanumeric)
+            .take(length)
+            .map(char::from)
+            .collect();
+
+        let exists = query!(
+            "SELECT short_code FROM short_links WHERE short_code = $1",
+            code
+        )
+        .fetch_optional(pool)
+        .await?;
+
+        if exists.is_none() {
+            return Ok(code);
+        }
+    }
+}

--- a/crates/va-link-server/src/lib.rs
+++ b/crates/va-link-server/src/lib.rs
@@ -1,0 +1,37 @@
+pub mod config;
+pub mod db;
+pub mod error;
+pub mod handlers;
+pub mod models;
+
+use axum::{
+    routing::{get, post},
+    Router,
+};
+use handlers::{AppStateData, AppState};
+use sqlx::PgPool;
+use tower_http::{
+    cors::{Any, CorsLayer},
+    trace::TraceLayer,
+};
+
+pub fn app(pool: PgPool, config: config::AppConfig) -> Router {
+    let state = AppStateData { pool, config };
+
+    let cors = CorsLayer::new()
+        .allow_methods(Any)
+        .allow_headers(Any)
+        .allow_origin(Any);
+
+    Router::new()
+        .route("/health", get(handlers::health_check))
+        .route("/links", post(handlers::create_short_link))
+        .route("/:short_code", get(handlers::redirect_short_link))
+        .route("/links/:short_code/stats", get(handlers::get_link_stats))
+        .with_state(state)
+        .layer(cors)
+        .layer(TraceLayer::new_for_http())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/va-link-server/src/main.rs
+++ b/crates/va-link-server/src/main.rs
@@ -1,12 +1,34 @@
 use anyhow::Result;
-use axum::{Router, routing::get};
+use axum::Router;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+use va_link_server::{app, config::AppConfig, db};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt().json().init();
-    let app = Router::new().route("/health", get(|| async { "ok" }));
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
-    tracing::info!("listening on {}", listener.local_addr()?);
-    axum::serve(listener, app).await?;
+    // Initialize tracing
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::new(
+            std::env::var("RUST_LOG")
+                .unwrap_or_else(|_| "va_link_server=debug,tower_http=debug".into()),
+        ))
+        .with(tracing_subscriber::fmt::layer().json())
+        .init();
+
+    // Load configuration
+    let config = AppConfig::load()?;
+    tracing::info!("Configuration loaded: {:?}", config);
+
+    // Initialize database pool and run migrations
+    let pool = db::init_db_pool(&config.database_url).await?;
+    db::run_migrations(&pool).await?;
+
+    // Build Axum app
+    let app = app(pool, config.clone());
+
+    // Start server
+    let listener = tokio::net::TcpListener::bind(&config.server_address).await?;
+    tracing::info!("Listening on {}", listener.local_addr()?);
+    axum::serve(listener, app.into_make_service()).await?;
     Ok(())
 }

--- a/crates/va-link-server/src/models.rs
+++ b/crates/va-link-server/src/models.rs
@@ -1,0 +1,65 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+use validator::Validate;
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct ShortLink {
+    pub id: Uuid,
+    pub original_url: String,
+    pub short_code: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub user_id: Option<Uuid>, // Optional, for authenticated users
+    pub clicks: i64,
+}
+
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize)]
+pub struct Click {
+    pub id: Uuid,
+    pub short_link_id: Uuid,
+    pub clicked_at: DateTime<Utc>,
+    pub ip_address: Option<String>,
+    pub user_agent: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub struct CreateLinkRequest {
+    #[validate(url(message = "Original URL must be a valid URL"))]
+    pub original_url: String,
+    #[validate(
+        length(
+            min = 4,
+            max = 20,
+            message = "Custom short code must be between 4 and 20 characters long"
+        ),
+        alphanumeric(message = "Custom short code must be alphanumeric")
+    )]
+    pub custom_short_code: Option<String>,
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LinkStats {
+    pub short_link: ShortLink,
+    pub total_clicks: i64,
+    pub last_click_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShortLinkResponse {
+    pub id: Uuid,
+    pub original_url: String,
+    pub short_code: String,
+    pub full_short_url: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub clicks: i64,
+}
+
+impl From<ShortLink> for ShortLinkResponse {
+    fn from(link: ShortLink) -> Self {
+        unimplemented!()
+    } // This will be implemented in handlers
+}

--- a/crates/va-link-server/src/tests.rs
+++ b/crates/va-link-server/src/tests.rs
@@ -1,0 +1,123 @@
+use crate::{app, config::AppConfig, db};
+use axum::{
+    body::Body,
+    http::{self, Request, StatusCode},
+};
+use http_body_util::BodyExt; // for `collect`
+use sqlx::{
+    postgres::{PgConnectOptions, PgPoolOptions},
+    PgPool,
+};
+use std::{str::FromStr, time::Duration};
+use tokio::net::TcpListener;
+use tower::ServiceExt; // for `call`, `oneshot`
+
+async fn setup_test_environment() -> (PgPool, AppConfig) {
+    // Use a unique database for each test run to prevent conflicts
+    let db_name = format!("test_va_link_{}", uuid::Uuid::new_v4().simple());
+    let admin_options = PgConnectOptions::from_str(
+        "postgres://postgres:password@localhost:5432/postgres",
+    )
+    .expect("Failed to parse admin DB URL");
+
+    let mut conn = sqlx::PgConnection::connect_with(&admin_options)
+        .await
+        .expect("Failed to connect to admin DB");
+
+    sqlx::query(&format!("DROP DATABASE IF EXISTS {}", db_name))
+        .execute(&mut conn)
+        .await
+        .expect("Failed to drop test database if exists");
+    sqlx::query(&format!("CREATE DATABASE {}", db_name))
+        .execute(&mut conn)
+        .await
+        .expect("Failed to create test database");
+
+    let test_db_url = format!("postgres://postgres:password@localhost:5432/{}", db_name);
+
+    let config = AppConfig {
+        database_url: test_db_url.clone(),
+        server_address: "127.0.0.1:0".to_string(), // Use port 0 for ephemeral port
+        short_code_length: 7,
+        base_url: "http://localhost:8080".to_string(),
+    };
+
+    let pool = PgPoolOptions::new()
+        .max_connections(1) // Use a single connection for tests
+        .connect(&test_db_url)
+        .await
+        .expect("Failed to connect to test database");
+
+    db::run_migrations(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    (pool, config)
+}
+
+#[tokio::test]
+async fn test_health_check() {
+    let (pool, config) = setup_test_environment().await;
+    let app = app(pool, config);
+
+    let response = app
+        .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_create_and_redirect_link() {
+    let (pool, config) = setup_test_environment().await;
+    let app = app(pool.clone(), config.clone());
+
+    // 1. Create a short link
+    let create_payload = serde_json::json!({
+        "original_url": "https://example.com/very/long/path/to/resource",
+        "custom_short_code": "mytestlink"
+    });
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(http::Method::POST)
+                .uri("/links")
+                .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+                .body(Body::from(create_payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let link_response: crate::models::ShortLinkResponse =
+        serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(link_response.original_url, "https://example.com/very/long/path/to/resource");
+    assert_eq!(link_response.short_code, "mytestlink");
+    assert!(link_response.full_short_url.contains("mytestlink"));
+
+    // 2. Redirect using the short code
+    let redirect_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/{}", link_response.short_code))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(redirect_response.status(), StatusCode::FOUND);
+    assert_eq!(
+        redirect_response.headers()["Location"],
+        "https://example.com/very/long/path/to/resource"
+    );
+
+    // 3. Get


### PR DESCRIPTION
## VA Agent (Rule Engine)

Diff-based code generation (C1)

**Files changed:**
- `crates/va-link-server/src/main.rs`
- `crates/va-link-server/Cargo.toml`
- `crates/va-link-server/src/config.rs`
- `crates/va-link-server/src/error.rs`
- `crates/va-link-server/src/models.rs`
- `crates/va-link-server/src/db.rs`
- `crates/va-link-server/src/handlers.rs`
- `crates/va-link-server/src/lib.rs`
- `crates/va-link-server/migrations/20260305000000_init.sql`
- `crates/va-link-server/src/tests.rs`

**Department**: dev | **Skill**: rust_backend

---
> ⚡ Generated deterministically by the Rule Engine — no LLM required.

*Generated by VertexAgents v12.0 Daemon*