### PR TITLE
[VA] #25: Implementar código fonte do va-link

### DIFF
--- a/crates/va-link-server/src/errors.rs
+++ b/crates/va-link-server/src/errors.rs
@@ -1,0 +1,51 @@
+use axum::{
+    Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde_json::json;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AppError {
+    #[error("not found")]
+    NotFound,
+
+    #[error("conflict: {0}")]
+    Conflict(String),
+
+    #[error("bad request: {0}")]
+    BadRequest(String),
+
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+
+    #[error("internal error: {0}")]
+    Internal(#[from] anyhow::Error),
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let (status, message) = match &self {
+            AppError::NotFound => (StatusCode::NOT_FOUND, self.to_string()),
+            AppError::Conflict(msg) => (StatusCode::CONFLICT, msg.clone()),
+            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            AppError::Database(e) => {
+                tracing::error!(error = %e, "database error");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal server error".to_string(),
+                )
+            }
+            AppError::Internal(e) => {
+                tracing::error!(error = %e, "internal error");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal server error".to_string(),
+                )
+            }
+        };
+        let body = Json(json!({ "error": message }));
+        (status, body).into_response()
+    }
+}

--- a/crates/va-link-server/src/handlers.rs
+++ b/crates/va-link-server/src/handlers.rs
@@ -1,0 +1,156 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Redirect},
+};
+use sqlx::PgPool;
+
+use crate::errors::AppError;
+use crate::models::{CreateLinkRequest, LinkResponse, UpdateLinkRequest};
+
+pub async fn health() -> &'static str {
+    "ok"
+}
+
+pub async fn create_link(
+    State(pool): State<PgPool>,
+    Json(req): Json<CreateLinkRequest>,
+) -> Result<(StatusCode, Json<LinkResponse>), AppError> {
+    if req.slug.is_empty() {
+        return Err(AppError::BadRequest("slug must not be empty".to_string()));
+    }
+    if req.target_url.is_empty() {
+        return Err(AppError::BadRequest(
+            "target_url must not be empty".to_string(),
+        ));
+    }
+
+    let link = sqlx::query_as!(
+        crate::models::Link,
+        r#"
+        INSERT INTO links (slug, target_url, title, click_count, active, created_at, updated_at)
+        VALUES ($1, $2, $3, 0, true, NOW(), NOW())
+        ON CONFLICT (slug) DO NOTHING
+        RETURNING id, slug, target_url, title, click_count, active, created_at, updated_at
+        "#,
+        req.slug,
+        req.target_url,
+        req.title,
+    )
+    .fetch_optional(&pool)
+    .await?;
+
+    match link {
+        Some(l) => Ok((StatusCode::CREATED, Json(LinkResponse::from(l)))),
+        None => Err(AppError::Conflict(format!(
+            "slug '{}' already exists",
+            req.slug
+        ))),
+    }
+}
+
+pub async fn get_link(
+    State(pool): State<PgPool>,
+    Path(slug): Path<String>,
+) -> Result<Json<LinkResponse>, AppError> {
+    let link = sqlx::query_as!(
+        crate::models::Link,
+        r#"
+        SELECT id, slug, target_url, title, click_count, active, created_at, updated_at
+        FROM links
+        WHERE slug = $1
+        "#,
+        slug,
+    )
+    .fetch_optional(&pool)
+    .await?;
+
+    match link {
+        Some(l) => Ok(Json(LinkResponse::from(l))),
+        None => Err(AppError::NotFound),
+    }
+}
+
+pub async fn update_link(
+    State(pool): State<PgPool>,
+    Path(slug): Path<String>,
+    Json(req): Json<UpdateLinkRequest>,
+) -> Result<Json<LinkResponse>, AppError> {
+    let link = sqlx::query_as!(
+        crate::models::Link,
+        r#"
+        UPDATE links
+        SET
+            target_url = COALESCE($2, target_url),
+            title      = COALESCE($3, title),
+            active     = COALESCE($4, active),
+            updated_at = NOW()
+        WHERE slug = $1
+        RETURNING id, slug, target_url, title, click_count, active, created_at, updated_at
+        "#,
+        slug,
+        req.target_url,
+        req.title,
+        req.active,
+    )
+    .fetch_optional(&pool)
+    .await?;
+
+    match link {
+        Some(l) => Ok(Json(LinkResponse::from(l))),
+        None => Err(AppError::NotFound),
+    }
+}
+
+pub async fn delete_link(
+    State(pool): State<PgPool>,
+    Path(slug): Path<String>,
+) -> Result<StatusCode, AppError> {
+    let result = sqlx::query!("DELETE FROM links WHERE slug = $1", slug,)
+        .execute(&pool)
+        .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(AppError::NotFound);
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn redirect_link(
+    State(pool): State<PgPool>,
+    Path(slug): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let link = sqlx::query_as!(
+        crate::models::Link,
+        r#"
+        UPDATE links
+        SET click_count = click_count + 1, updated_at = NOW()
+        WHERE slug = $1 AND active = true
+        RETURNING id, slug, target_url, title, click_count, active, created_at, updated_at
+        "#,
+        slug,
+    )
+    .fetch_optional(&pool)
+    .await?;
+
+    match link {
+        Some(l) => Ok(Redirect::temporary(&l.target_url)),
+        None => Err(AppError::NotFound),
+    }
+}
+
+pub async fn list_links(State(pool): State<PgPool>) -> Result<Json<Vec<LinkResponse>>, AppError> {
+    let links = sqlx::query_as!(
+        crate::models::Link,
+        r#"
+        SELECT id, slug, target_url, title, click_count, active, created_at, updated_at
+        FROM links
+        ORDER BY created_at DESC
+        "#,
+    )
+    .fetch_all(&pool)
+    .await?;
+
+    Ok(Json(links.into_iter().map(LinkResponse::from).collect()))
+}

--- a/crates/va-link-server/src/handlers_test.rs
+++ b/crates/va-link-server/src/handlers_test.rs
@@ -1,0 +1,117 @@
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Method, Request, StatusCode},
+    };
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    use crate::models::{CreateLinkRequest, LinkResponse};
+
+    fn make_create_request(slug: &str, url: &str) -> CreateLinkRequest {
+        CreateLinkRequest {
+            slug: slug.to_string(),
+            target_url: url.to_string(),
+            title: None,
+        }
+    }
+
+    #[test]
+    fn test_create_link_request_fields() {
+        let req = make_create_request("test-slug", "https://example.com");
+        assert_eq!(req.slug, "test-slug");
+        assert_eq!(req.target_url, "https://example.com");
+        assert!(req.title.is_none());
+    }
+
+    #[test]
+    fn test_create_link_request_with_title() {
+        let req = CreateLinkRequest {
+            slug: "my-link".to_string(),
+            target_url: "https://example.com/path".to_string(),
+            title: Some("My Link Title".to_string()),
+        };
+        assert_eq!(req.slug, "my-link");
+        assert_eq!(req.title, Some("My Link Title".to_string()));
+    }
+
+    #[test]
+    fn test_link_response_from_model() {
+        use crate::models::Link;
+        let now = chrono::Utc::now();
+        let link = Link {
+            id: 1,
+            slug: "abc".to_string(),
+            target_url: "https://example.com".to_string(),
+            title: None,
+            click_count: 42,
+            active: true,
+            created_at: now,
+            updated_at: now,
+        };
+        let resp = LinkResponse::from(link);
+        assert_eq!(resp.id, 1);
+        assert_eq!(resp.slug, "abc");
+        assert_eq!(resp.click_count, 42);
+        assert!(resp.active);
+    }
+
+    #[test]
+    fn test_update_link_request_all_none() {
+        use crate::models::UpdateLinkRequest;
+        let req = UpdateLinkRequest {
+            target_url: None,
+            title: None,
+            active: None,
+        };
+        assert!(req.target_url.is_none());
+        assert!(req.title.is_none());
+        assert!(req.active.is_none());
+    }
+
+    #[test]
+    fn test_update_link_request_partial() {
+        use crate::models::UpdateLinkRequest;
+        let req = UpdateLinkRequest {
+            target_url: Some("https://new-url.com".to_string()),
+            title: None,
+            active: Some(false),
+        };
+        assert_eq!(req.target_url, Some("https://new-url.com".to_string()));
+        assert!(req.title.is_none());
+        assert_eq!(req.active, Some(false));
+    }
+
+    #[test]
+    fn test_slug_empty_validation() {
+        let req = make_create_request("", "https://example.com");
+        assert!(req.slug.is_empty());
+    }
+
+    #[test]
+    fn test_target_url_empty_validation() {
+        let req = make_create_request("slug", "");
+        assert!(req.target_url.is_empty());
+    }
+
+    #[test]
+    fn test_link_serialization() {
+        use crate::models::Link;
+        let now = chrono::Utc::now();
+        let link = Link {
+            id: 10,
+            slug: "serialize-test".to_string(),
+            target_url: "https://serialize.example.com".to_string(),
+            title: Some("Serialization Test".to_string()),
+            click_count: 0,
+            active: true,
+            created_at: now,
+            updated_at: now,
+        };
+        let json_val = serde_json::to_value(&link).expect("serialization failed");
+        assert_eq!(json_val["slug"], "serialize-test");
+        assert_eq!(json_val["click_count"], 0);
+        assert_eq!(json_val["active"], true);
+    }
+}

--- a/crates/va-link-server/src/lib.rs
+++ b/crates/va-link-server/src/lib.rs
@@ -1,0 +1,30 @@
+use anyhow::Result;
+use sqlx::PgPool;
+
+pub async fn create_pool(database_url: &str) -> Result<PgPool> {
+    let pool = PgPool::connect(database_url).await?;
+    Ok(pool)
+}
+
+pub fn database_url() -> String {
+    std::env::var("DATABASE_URL").expect("DATABASE_URL must be set")
+}
+
+#[cfg(test)]
+pub fn test_database_url() -> String {
+    std::env::var("TEST_DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/va_link_test".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_database_url_fallback() {
+        if std::env::var("TEST_DATABASE_URL").is_err() {
+            let url = test_database_url();
+            assert!(url.contains("va_link_test"));
+        }
+    }
+}

--- a/crates/va-link-server/src/main.rs
+++ b/crates/va-link-server/src/main.rs
@@ -6,28 +6,8 @@ use axum::{
 
 mod errors;
 mod handlers;
+mod handlers_test;
 mod lib;
 mod models;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    tracing_subscriber::fmt().json().init();
-
-    let database_url = lib::database_url();
-    let pool = lib::create_pool(&database_url).await?;
-
-    let app = Router::new()
-        .route("/health", get(handlers::health))
-        .route("/links", get(handlers::list_links))
-        .route("/links", post(handlers::create_link))
-        .route("/links/:slug", get(handlers::get_link))
-        .route("/links/:slug", put(handlers::update_link))
-        .route("/links/:slug", delete(handlers::delete_link))
-        .route("/r/:slug", get(handlers::redirect_link))
-        .with_state(pool);
-
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
-    tracing::info!("listening on {}", listener.local_addr()?);
-    axum::serve(listener, app).await?;
     Ok(())
 }

--- a/crates/va-link-server/src/main.rs
+++ b/crates/va-link-server/src/main.rs
@@ -1,10 +1,31 @@
 use anyhow::Result;
-use axum::{Router, routing::get};
+use axum::{
+    Router,
+    routing::{delete, get, post, put},
+};
+
+mod errors;
+mod handlers;
+mod lib;
+mod models;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt().json().init();
-    let app = Router::new().route("/health", get(|| async { "ok" }));
+
+    let database_url = lib::database_url();
+    let pool = lib::create_pool(&database_url).await?;
+
+    let app = Router::new()
+        .route("/health", get(handlers::health))
+        .route("/links", get(handlers::list_links))
+        .route("/links", post(handlers::create_link))
+        .route("/links/:slug", get(handlers::get_link))
+        .route("/links/:slug", put(handlers::update_link))
+        .route("/links/:slug", delete(handlers::delete_link))
+        .route("/r/:slug", get(handlers::redirect_link))
+        .with_state(pool);
+
     let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
     tracing::info!("listening on {}", listener.local_addr()?);
     axum::serve(listener, app).await?;

--- a/crates/va-link-server/src/models.rs
+++ b/crates/va-link-server/src/models.rs
@@ -1,0 +1,55 @@
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+pub struct Link {
+    pub id: i64,
+    pub slug: String,
+    pub target_url: String,
+    pub title: Option<String>,
+    pub click_count: i64,
+    pub active: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateLinkRequest {
+    pub slug: String,
+    pub target_url: String,
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateLinkRequest {
+    pub target_url: Option<String>,
+    pub title: Option<String>,
+    pub active: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LinkResponse {
+    pub id: i64,
+    pub slug: String,
+    pub target_url: String,
+    pub title: Option<String>,
+    pub click_count: i64,
+    pub active: bool,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<Link> for LinkResponse {
+    fn from(l: Link) -> Self {
+        Self {
+            id: l.id,
+            slug: l.slug,
+            target_url: l.target_url,
+            title: l.title,
+            click_count: l.click_count,
+            active: l.active,
+            created_at: l.created_at,
+            updated_at: l.updated_at,
+        }
+    }
+}

--- a/migrations/001_create_links.sql
+++ b/migrations/001_create_links.sql
@@ -1,0 +1,17 @@
+-- Migration: 001_create_links
+-- Creates the links table for va-link short URL service
+
+CREATE TABLE IF NOT EXISTS links (
+    id          BIGSERIAL PRIMARY KEY,
+    slug        TEXT        NOT NULL,
+    target_url  TEXT        NOT NULL,
+    title       TEXT,
+    click_count BIGINT      NOT NULL DEFAULT 0,
+    active      BOOLEAN     NOT NULL DEFAULT true,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS links_slug_idx ON links (slug);
+CREATE INDEX IF NOT EXISTS links_active_idx ON links (active);
+CREATE INDEX IF NOT EXISTS links_created_at_idx ON links (created_at DESC);


### PR DESCRIPTION
## VA Agent (Rule Engine)

Diff-based code generation (C1)

**Files changed:**
- `crates/va-link-server/src/lib.rs`
- `crates/va-link-server/src/models.rs`
- `crates/va-link-server/src/errors.rs`
- `crates/va-link-server/src/handlers.rs`
- `crates/va-link-server/src/main.rs`
- `migrations/001_create_links.sql`
- `crates/va-link-server/src/handlers_test.rs`
- `crates/va-link-server/src/main.rs`

**Department**: ops | **Skill**: devops

---
> ⚡ Generated deterministically by the Rule Engine — no LLM required.

*Generated by VertexAgents v12.0 Daemon*