### PR TITLE
[VA] #27: Implementar código fonte do va-link

### DIFF
--- a/crates/va-link-server/Cargo.toml
+++ b/crates/va-link-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "va-link-server"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 axum.workspace = true
@@ -13,3 +13,8 @@ thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 sqlx.workspace = true
+chrono = { version = "0.4", features = ["serde"] }
+
+[dev-dependencies]
+tower = { version = "0.4", features = ["util"] }
+tokio = { version = "1", features = ["full"] }

--- a/crates/va-link-server/migrations/001_create_links.sql
+++ b/crates/va-link-server/migrations/001_create_links.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS links (
+    id          BIGSERIAL PRIMARY KEY,
+    slug        TEXT        NOT NULL UNIQUE,
+    target_url  TEXT        NOT NULL,
+    title       TEXT,
+    click_count BIGINT      NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_links_slug ON links (slug);

--- a/crates/va-link-server/src/db.rs
+++ b/crates/va-link-server/src/db.rs
@@ -1,0 +1,12 @@
+use anyhow::Result;
+use sqlx::PgPool;
+
+pub async fn create_pool(database_url: &str) -> Result<PgPool> {
+    let pool = PgPool::connect(database_url).await?;
+    Ok(pool)
+}
+
+pub async fn run_migrations(pool: &PgPool) -> Result<()> {
+    sqlx::migrate!("./migrations").run(pool).await?;
+    Ok(())
+}

--- a/crates/va-link-server/src/error.rs
+++ b/crates/va-link-server/src/error.rs
@@ -1,0 +1,46 @@
+use axum::{
+    Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde_json::json;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AppError {
+    #[error("not found")]
+    NotFound,
+    #[error("bad request: {0}")]
+    BadRequest(String),
+    #[error("internal error: {0}")]
+    Internal(#[from] anyhow::Error),
+    #[error("database error: {0}")]
+    Database(#[from] sqlx::Error),
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let (status, message) = match &self {
+            AppError::NotFound => (StatusCode::NOT_FOUND, self.to_string()),
+            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            AppError::Internal(e) => {
+                tracing::error!(error = %e, "internal error");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal server error".to_string(),
+                )
+            }
+            AppError::Database(e) => {
+                tracing::error!(error = %e, "database error");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal server error".to_string(),
+                )
+            }
+        };
+        let body = Json(json!({ "error": message }));
+        (status, body).into_response()
+    }
+}
+
+pub type AppResult<T> = Result<T, AppError>;

--- a/crates/va-link-server/src/handlers/links.rs
+++ b/crates/va-link-server/src/handlers/links.rs
@@ -1,0 +1,143 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+
+use crate::error::AppError;
+use crate::error::AppResult;
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct Link {
+    pub id: i64,
+    pub slug: String,
+    pub target_url: String,
+    pub title: Option<String>,
+    pub click_count: i64,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateLinkRequest {
+    pub slug: String,
+    pub target_url: String,
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateLinkRequest {
+    pub target_url: Option<String>,
+    pub title: Option<String>,
+}
+
+pub async fn list_links(State(pool): State<PgPool>) -> AppResult<Json<Vec<Link>>> {
+    let links = sqlx::query_as!(
+        Link,
+        r#"SELECT id, slug, target_url, title, click_count, created_at, updated_at
+           FROM links
+           ORDER BY created_at DESC"#
+    )
+    .fetch_all(&pool)
+    .await?;
+    Ok(Json(links))
+}
+
+pub async fn get_link(
+    State(pool): State<PgPool>,
+    Path(slug): Path<String>,
+) -> AppResult<Json<Link>> {
+    let link = sqlx::query_as!(
+        Link,
+        r#"SELECT id, slug, target_url, title, click_count, created_at, updated_at
+           FROM links
+           WHERE slug = $1"#,
+        slug
+    )
+    .fetch_optional(&pool)
+    .await?
+    .ok_or(AppError::NotFound)?;
+    Ok(Json(link))
+}
+
+pub async fn create_link(
+    State(pool): State<PgPool>,
+    Json(req): Json<CreateLinkRequest>,
+) -> AppResult<Json<Link>> {
+    if req.slug.trim().is_empty() {
+        return Err(AppError::BadRequest("slug must not be empty".to_string()));
+    }
+    if req.target_url.trim().is_empty() {
+        return Err(AppError::BadRequest(
+            "target_url must not be empty".to_string(),
+        ));
+    }
+    let link = sqlx::query_as!(
+        Link,
+        r#"INSERT INTO links (slug, target_url, title)
+           VALUES ($1, $2, $3)
+           RETURNING id, slug, target_url, title, click_count, created_at, updated_at"#,
+        req.slug.trim(),
+        req.target_url.trim(),
+        req.title.as_deref().map(str::trim)
+    )
+    .fetch_one(&pool)
+    .await?;
+    Ok(Json(link))
+}
+
+pub async fn update_link(
+    State(pool): State<PgPool>,
+    Path(slug): Path<String>,
+    Json(req): Json<UpdateLinkRequest>,
+) -> AppResult<Json<Link>> {
+    let link = sqlx::query_as!(
+        Link,
+        r#"UPDATE links
+           SET target_url  = COALESCE($2, target_url),
+               title       = COALESCE($3, title),
+               updated_at  = NOW()
+           WHERE slug = $1
+           RETURNING id, slug, target_url, title, click_count, created_at, updated_at"#,
+        slug,
+        req.target_url.as_deref().map(str::trim),
+        req.title.as_deref().map(str::trim)
+    )
+    .fetch_optional(&pool)
+    .await?
+    .ok_or(AppError::NotFound)?;
+    Ok(Json(link))
+}
+
+pub async fn delete_link(
+    State(pool): State<PgPool>,
+    Path(slug): Path<String>,
+) -> AppResult<axum::http::StatusCode> {
+    let result = sqlx::query!(r#"DELETE FROM links WHERE slug = $1"#, slug)
+        .execute(&pool)
+        .await?;
+    if result.rows_affected() == 0 {
+        return Err(AppError::NotFound);
+    }
+    Ok(axum::http::StatusCode::NO_CONTENT)
+}
+
+pub async fn redirect_link(
+    State(pool): State<PgPool>,
+    Path(slug): Path<String>,
+) -> AppResult<axum::response::Redirect> {
+    let link = sqlx::query_as!(
+        Link,
+        r#"UPDATE links
+           SET click_count = click_count + 1,
+               updated_at  = NOW()
+           WHERE slug = $1
+           RETURNING id, slug, target_url, title, click_count, created_at, updated_at"#,
+        slug
+    )
+    .fetch_optional(&pool)
+    .await?
+    .ok_or(AppError::NotFound)?;
+    Ok(axum::response::Redirect::permanent(&link.target_url))
+}

--- a/crates/va-link-server/src/handlers/mod.rs
+++ b/crates/va-link-server/src/handlers/mod.rs
@@ -1,0 +1,1 @@
+pub mod links;

--- a/crates/va-link-server/src/lib.rs
+++ b/crates/va-link-server/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod db;
+pub mod error;
+pub mod handlers;
+pub mod router;

--- a/crates/va-link-server/src/main.rs
+++ b/crates/va-link-server/src/main.rs
@@ -1,10 +1,21 @@
 use anyhow::Result;
-use axum::{Router, routing::get};
+use va_link_server::{db, router};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt().json().init();
-    let app = Router::new().route("/health", get(|| async { "ok" }));
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "va_link_server=info,axum=info".parse().unwrap()),
+        )
+        .json()
+        .init();
+
+    let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let pool = db::create_pool(&database_url).await?;
+    db::run_migrations(&pool).await?;
+
+    let app = router::build(pool);
     let listener = tokio::net::TcpListener::bind("0.0.0.0:8080").await?;
     tracing::info!("listening on {}", listener.local_addr()?);
     axum::serve(listener, app).await?;

--- a/crates/va-link-server/src/router.rs
+++ b/crates/va-link-server/src/router.rs
@@ -1,0 +1,24 @@
+use axum::{
+    Router,
+    routing::{delete, get, post, put},
+};
+use sqlx::PgPool;
+
+use crate::handlers::links;
+
+pub fn build(pool: PgPool) -> Router {
+    Router::new()
+        .route("/health", get(|| async { "ok" }))
+        .route(
+            "/api/links",
+            get(links::list_links).post(links::create_link),
+        )
+        .route(
+            "/api/links/:slug",
+            get(links::get_link)
+                .put(links::update_link)
+                .delete(links::delete_link),
+        )
+        .route("/r/:slug", get(links::redirect_link))
+        .with_state(pool)
+}

--- a/crates/va-link-server/tests/links_test.rs
+++ b/crates/va-link-server/tests/links_test.rs
@@ -1,0 +1,118 @@
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+async fn test_pool() -> sqlx::PgPool {
+    let url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:postgres@localhost/va_link_test".to_string());
+    let pool = sqlx::PgPool::connect(&url).await.expect("connect");
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .expect("migrate");
+    sqlx::query!("DELETE FROM links")
+        .execute(&pool)
+        .await
+        .expect("clean");
+    pool
+}
+
+#[tokio::test]
+async fn test_health() {
+    let pool = test_pool().await;
+    let app = va_link_server::router::build(pool);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_create_and_get_link() {
+    let pool = test_pool().await;
+    let app = va_link_server::router::build(pool);
+
+    let body = serde_json::to_vec(&json!({
+        "slug": "test-slug",
+        "target_url": "https://example.com",
+        "title": "Example"
+    }))
+    .unwrap();
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/links")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let val: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(val["slug"], "test-slug");
+    assert_eq!(val["click_count"], 0);
+
+    let resp2 = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/links/test-slug")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp2.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_not_found() {
+    let pool = test_pool().await;
+    let app = va_link_server::router::build(pool);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/links/nonexistent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_create_link_empty_slug() {
+    let pool = test_pool().await;
+    let app = va_link_server::router::build(pool);
+    let body =
+        serde_json::to_vec(&json!({"slug": "  ", "target_url": "https://example.com"})).unwrap();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/links")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}


### PR DESCRIPTION
## VA Agent (Rule Engine)

Diff-based code generation (C1)

**Files changed:**
- `crates/va-link-server/src/db.rs`
- `crates/va-link-server/src/error.rs`
- `crates/va-link-server/src/handlers/links.rs`
- `crates/va-link-server/src/handlers/mod.rs`
- `crates/va-link-server/src/lib.rs`
- `crates/va-link-server/src/router.rs`
- `crates/va-link-server/src/main.rs`
- `crates/va-link-server/migrations/001_create_links.sql`
- `crates/va-link-server/tests/links_test.rs`
- `crates/va-link-server/Cargo.toml`

**Department**: ops | **Skill**: devops

---
> ⚡ Generated deterministically by the Rule Engine — no LLM required.

*Generated by VertexAgents v12.0 Daemon*