### PR TITLE
[VA] #47: Implementar código fonte do va-link

### DIFF
--- a/crates/va-link-server/Cargo.toml
+++ b/crates/va-link-server/Cargo.toml
@@ -13,3 +13,4 @@ thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 sqlx.workspace = true
+uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/crates/va-link-server/src/db.rs
+++ b/crates/va-link-server/src/db.rs
@@ -1,0 +1,19 @@
+use anyhow::{Context, Result};
+use sqlx::PgPool;
+use tracing::info;
+
+pub async fn setup_database(database_url: &str) -> Result<PgPool> {
+    info!("Connecting to database...");
+    let pool = PgPool::connect(database_url)
+        .await
+        .context("Failed to connect to Postgres")?;
+
+    info!("Running database migrations...");
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .context("Failed to run database migrations")?;
+
+    info!("Database setup complete.");
+    Ok(pool)
+}

--- a/crates/va-link-server/src/handlers.rs
+++ b/crates/va-link-server/src/handlers.rs
@@ -1,0 +1,92 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use sqlx::PgPool;
+use tracing::error;
+use uuid::Uuid;
+
+use crate::models::{CreateLink, Link};
+
+#[derive(Clone)]
+pub struct AppState {
+    pub pool: PgPool,
+}
+
+pub async fn create_link(
+    State(state): State<AppState>,
+    Json(payload): Json<CreateLink>,
+) -> impl IntoResponse {
+    let new_link = Link {
+        id: Uuid::new_v4(),
+        original_url: payload.original_url,
+        short_code: payload.short_code,
+        created_at: chrono::Utc::now(),
+    };
+
+    match sqlx::query_as!(
+        Link,
+        r#"
+        INSERT INTO links (id, original_url, short_code, created_at)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id, original_url, short_code, created_at
+        "#,
+        new_link.id,
+        new_link.original_url,
+        new_link.short_code,
+        new_link.created_at
+    )
+    .fetch_one(&state.pool)
+    .await
+    {
+        Ok(link) => (StatusCode::CREATED, Json(link)).into_response(),
+        Err(e) => {
+            error!("Failed to create link: {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Failed to create link").into_response()
+        }
+    }
+}
+
+pub async fn get_link(State(state): State<AppState>, Path(id): Path<Uuid>) -> impl IntoResponse {
+    match sqlx::query_as!(
+        Link,
+        r#"
+        SELECT id, original_url, short_code, created_at
+        FROM links
+        WHERE id = $1
+        "#,
+        id
+    )
+    .fetch_optional(&state.pool)
+    .await
+    {
+        Ok(Some(link)) => (StatusCode::OK, Json(link)).into_response(),
+        Ok(None) => (StatusCode::NOT_FOUND, "Link not found").into_response(),
+        Err(e) => {
+            error!("Failed to retrieve link: {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Failed to retrieve link").into_response()
+        }
+    }
+}
+
+pub async fn list_links(State(state): State<AppState>) -> impl IntoResponse {
+    match sqlx::query_as!(
+        Link,
+        r#"
+        SELECT id, original_url, short_code, created_at
+        FROM links
+        ORDER BY created_at DESC
+        "#
+    )
+    .fetch_all(&state.pool)
+    .await
+    {
+        Ok(links) => (StatusCode::OK, Json(links)).into_response(),
+        Err(e) => {
+            error!("Failed to list links: {:?}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Failed to list links").into_response()
+        }
+    }
+}

--- a/crates/va-link-server/src/models.rs
+++ b/crates/va-link-server/src/models.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, FromRow)]
+pub struct Link {
+    pub id: uuid::Uuid,
+    pub original_url: String,
+    pub short_code: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CreateLink {
+    pub original_url: String,
+    pub short_code: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_link_struct() {
+        let create_link = CreateLink {
+            original_url: "https://example.com".to_string(),
+            short_code: "abc".to_string(),
+        };
+        assert_eq!(create_link.original_url,


### PR DESCRIPTION
## VA Agent (Rule Engine)

Diff-based code generation (C1)

**Files changed:**
- `crates/va-link-server/Cargo.toml`
- `crates/va-link-server/src/db.rs`
- `crates/va-link-server/src/handlers.rs`
- `crates/va-link-server/src/models.rs`

**Department**: ops | **Skill**: devops

---
> ⚡ Generated deterministically by the Rule Engine — no LLM required.

*Generated by VertexAgents v12.0 Daemon*