### PR TITLE
[VA] #69: Implementar código fonte do va-link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [workspace]
-members = ["crates/va-link-server"]
-resolver = "2"
+members = [
+    "crates/va-server",
+    "crates/va-link",
+]
 
-[workspace.dependencies]
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/va-link/Cargo.toml
+++ b/crates/va-link/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "va-link"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+actix-web = "4"
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "migrate"] }
+dotenvy = "0.15"
+uuid = { version = "1.0", features = ["v4", "serde"] }
+chrono = { version = "0.4", features = ["serde"] }
+jsonwebtoken = "8"
+hmac = "0.12"
+sha2 = "0.10"
+anyhow = "1.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+opentelemetry = { version = "0.20", features = ["rt-tokio"] }
+opentelemetry-otlp = { version = "0.13", features = ["grpc-tonic", "trace"] }
+opentelemetry_sdk = { version = "0.20", features = ["rt-tokio"] }
+futures = "0.3"
+hex = "0.4"
+rand = "0.8"
+

--- a/crates/va-link/src/handlers.rs
+++ b/crates/va-link/src/handlers.rs
@@ -1,0 +1,14 @@
+use crate::lib::hash_api_key;
+use crate::main::AppState; // Import AppState from main
+use crate::models::{CreateLink, Link};
+use actix_web::{HttpResponse, Responder, http::header, web};
+use anyhow::Result;
+use chrono::{DateTime, Duration, Utc};
+use rand::Rng;
+use sqlx::{PgPool, query, query_as};
+use tracing::{error, info};
+use uuid::Uuid;
+
+pub async fn health_check() -> impl Responder {
+    HttpResponse::Ok().body("OK")
+}

--- a/crates/va-link/src/lib.rs
+++ b/crates/va-link/src/lib.rs
@@ -1,0 +1,12 @@
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+pub type HmacSha256 = Hmac<Sha256>;
+
+pub fn hash_api_key(api_key: &str, secret: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret).expect("HMAC can take key of any size");
+    mac.update(api_key.as_bytes());
+    hex::encode(mac.finalize().into_bytes())
+}
+
+// verify_api_key is not strictly needed for this service, as we only store the hash.

--- a/crates/va-link/src/main.rs
+++ b/crates/va-link/src/main.rs
@@ -1,0 +1,106 @@
+use actix_web::{web, App, HttpServer};
+use sqlx::PgPool;
+use dotenvy::dotenv;
+use std::env;
+use tracing::{info, error, Level};
+use tracing_subscriber::FmtSubscriber;
+use opentelemetry::{global, KeyValue};
+use opentelemetry_otlp::{WithExportConfig, new_pipeline};
+use opentelemetry_sdk::{trace as sdktrace, Resource};
+use futures::FutureExt;
+
+mod handlers;
+mod models;
+mod lib; // For API key hashing
+
+pub struct AppState {
+    pub db_pool: PgPool,
+    pub hmac_secret: Vec<u8>,
+}
+
+#[actix_web::main]
+async fn main() -> anyhow::Result<()> {
+    dotenv().ok();
+
+    // Initialize tracing
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::INFO)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("setting default subscriber failed");
+
+    // Initialize OpenTelemetry
+    init_otel_tracer()?;
+
+    info!("Starting va-link service...");
+
+    let database_url = env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set");
+    let hmac_secret_key = env::var("HMAC_SECRET_KEY")
+        .expect("HMAC_SECRET_KEY must be set");
+    let server_address = env::var("SERVER_ADDRESS")
+        .unwrap_or_else(|_| "127.0.0.1:8080".to_string());
+
+    let pool = PgPool::connect(&database_url).await?;
+    info!("Database connection established.");
+
+    // Run migrations
+    info!("Running database migrations...");
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .map_err(|e| {
+            error!("Failed to run migrations: {:?}", e);
+            e
+        })?;
+    info!("Database migrations completed.");
+
+    let hmac_secret = hmac_secret_key.as_bytes().to_vec();
+
+    let app_state = web::Data::new(AppState {
+        db_pool: pool.clone(),
+        hmac_secret,
+    });
+
+    info!("Server starting at: {}", server_address);
+
+    HttpServer::new(move || {
+        App::new()
+            .app_data(app_state.clone()) // AppState for handlers
+            .service(web::resource("/health").to(handlers::health_check))
+            .service(web::resource("/link").route(web::post().to(handlers::create_link)))
+            .service(web::resource("/{short_code}").route(web::get().to(handlers::redirect_link)))
+    })
+    .bind(&server_address)?
+    .run()
+    .await?;
+
+    // Shutdown OpenTelemetry tracer
+    global::shutdown_tracer_provider();
+
+    Ok(())
+}
+
+fn init_otel_tracer() -> anyhow::Result<()> {
+    let collector_url = env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+        .unwrap_or_else(|_| "http://localhost:4317".to_string());
+
+    let tracer = new_pipeline()
+        .tracing()
+        .with_exporter(
+            opentelemetry_otlp::new_exporter()
+                .tonic()
+                .with_endpoint(collector_url),
+        )
+        .with_trace_config(
+            sdktrace::config().with_resource(Resource::new(vec![
+                KeyValue::new("service.name", "va-link"),
+                KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
+            ])),
+        )
+        .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+
+    global::set_tracer_provider(tracer.provider().expect("Failed to get tracer provider"));
+
+    Ok(())
+}

--- a/crates/va-link/src/models.rs
+++ b/crates/va-link/src/models.rs
@@ -1,0 +1,24 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use uuid::Uuid;
+
+#[derive(Debug, FromRow, Serialize, Deserialize)]
+pub struct Link {
+    pub id: Uuid,
+    pub short_code: String,
+    pub original_url: String,
+    pub tenant_id: String,
+    pub api_key_hash: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub click_count: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateLink {
+    pub original_url: String,
+    // Optional expiration date for the short link
+    // If not provided, the link might not expire or have a default expiration set by business logic.
+    pub expires_at: Option<DateTime<Utc>>,
+}


### PR DESCRIPTION
## VA Agent (Rule Engine)

Diff-based code generation (C1)

**Files changed:**
- `Cargo.toml`
- `crates/va-link/Cargo.toml`
- `crates/va-link/src/main.rs`
- `crates/va-link/src/lib.rs`
- `crates/va-link/src/models.rs`
- `crates/va-link/src/handlers.rs`

**Department**: ops | **Skill**: devops

---
> ⚡ Generated deterministically by the Rule Engine — no LLM required.

*Generated by VertexAgents v12.0 Daemon*