### PR TITLE
[VA] #74: Implementar código fonte do va-link

### DIFF
--- a/crates/va-link/Cargo.toml
+++ b/crates/va-link/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "va-link"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+actix-web = "4"
+actix-web-httpauth = "0.6" # Not strictly needed with custom extractor, but good to keep for future
+diesel = { version = "2.1.0", features = ["postgres", "r2d2", "uuid", "chrono"] }
+dotenvy = "0.15"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+uuid = { version = "1.0", features = ["v4", "serde"] }
+chrono = { version = "0.4", features = ["serde"] }
+rand = "0.8"
+log = "0.4"
+env_logger = "0.10"

--- a/crates/va-link/src/db.rs
+++ b/crates/va-link/src/db.rs
@@ -1,0 +1,5 @@
+use diesel::prelude::*;
+use diesel::r2d2::{ConnectionManager, PooledConnection};
+use uuid::Uuid;
+
+use crate::models::{Link, New


### PR DESCRIPTION
## VA Agent (Rule Engine)

Diff-based code generation (C1)

**Files changed:**
- `crates/va-link/Cargo.toml`
- `crates/va-link/src/db.rs`

**Department**: ops | **Skill**: devops

---
> ⚡ Generated deterministically by the Rule Engine — no LLM required.

*Generated by VertexAgents v12.0 Daemon*