### PR TITLE
[VA] #77: Implementar código fonte do va-link

### DIFF
--- a/va-notes/issue-77.md
+++ b/va-notes/issue-77.md
@@ -1,0 +1,12 @@
+# VA Agent Output — Issue #77
+
+> JSON parsing failed: missing field `files` at line 4 column 1
+
+## Raw LLM Output
+
+```json
+{
+  "commit_message": "feat: Implement va-link service with CRUD, redirect, and migrations",
+  "description": "This commit implements the core functionality for the `va-link` service, addressing Issue #77. It includes:\n\n- **Database Migration**: A new SQL migration (`0001_create_links_table.sql`) to set up the `links` table with `tenant_id`, RLS, `BIGSERIAL` primary keys, and `TIMESTAMPTZ` timestamps, following project conventions.\n- **Data Models**: Rust structs (`Link`, `CreateLinkRequest`, `UpdateLinkRequest`) for representing link data and API payloads.\n- **Repository Layer**: `LinkRepository` for direct database interactions (CRUD operations).\n- **Service Layer**: `LinkService` encapsulating business logic, including short code generation and uniqueness checks.\n- **API Endpoints**: `actix-web` handlers for:\n    - `POST /links`: Create a new short link.\n    - `GET /links`: Retrieve all links for a tenant.\n    - `GET /links/{id}`: Retrieve a specific link by ID.\n    - `PUT /links/{id}`: Update an existing link.\n    - `DELETE /links/{id}`: Delete a link.\n    - `GET /{short_code}`: Redirect to the original URL based on the short code.\n- **Application Setup**: `main.rs` configured to initialize the database, run migrations, set up the Actix-web server, and register routes."
+}
+```


### PR DESCRIPTION
## VA Agent

Analysis result — no code changes parsed

**Files changed:**
- `va-notes/issue-77.md`

**Model**: gemini-3.1-pro-preview | **Department**: ops | **Skill**: devops

---
> ✅ **Before merging**: Wait for CI (`cargo check + cargo test`) to pass. Review all modified files for completeness — do not merge if any file looks like a stub.

*Generated by VertexAgents v9.0 Daemon*

> ⚠️ JSON parse failed — this PR contains the raw LLM output as a note file.